### PR TITLE
fixed Certificate not visible in Experience section.

### DIFF
--- a/Priyanka-Portfolio/src/data/constants.js
+++ b/Priyanka-Portfolio/src/data/constants.js
@@ -134,7 +134,7 @@ export const experiences = [
       "Jenkins",
       "Red Hat OpenShift",
     ],
-    doc: "https://drive.google.com/file/d/1SGyd2edJqVU0jUklN6WC-cQ6apK4F5ZM/view?usp=sharing",
+    doc: "https://github.com/sonu82256/Github-pics/blob/main/intellect_intern_certificate.png?raw=true",
   },
   
 ];


### PR DESCRIPTION
##What does this PR do?

This PR fixes the issue where the certificate image was not showing in the Experience section when the mouse was hovered over it.

Fixes #1

<img width="782" alt="Screenshot 2024-08-25 at 5 13 16 PM" src="https://github.com/user-attachments/assets/355e1e27-3f70-4e42-9b2b-bb413c8c5c88">

##Type of issue
-Bug fix (non-breaking changes which fix an issue)

##How should this be tested?
-[] go to homepage
-[] go to experience section

##Mandatory Task
-[X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
